### PR TITLE
fix tracer when a single part is needed

### DIFF
--- a/collector_client.go
+++ b/collector_client.go
@@ -38,13 +38,14 @@ type reportRequest struct {
 // SplitByParts splits reportRequest into given number of parts.
 // Beware, that parts=0 panics.
 func (rr reportRequest) SplitByParts(parts int) []reportRequest {
-	spans := rr.protoRequest.Spans
-	if len(spans) == 0 {
+
+	if rr.protoRequest == nil || len(rr.protoRequest.Spans) == 0 || parts <= 1 {
 		return []reportRequest{rr}
 	}
+	spans := rr.protoRequest.Spans
 
 	maxSize := len(rr.protoRequest.Spans) / parts
-	if len(rr.protoRequest.Spans) % parts > 0 {
+	if len(rr.protoRequest.Spans)%parts > 0 {
 		maxSize++
 	}
 

--- a/tracer_impl_test.go
+++ b/tracer_impl_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb"
 	"github.com/lightstep/lightstep-tracer-common/golang/gogo/collectorpb/collectorpbfakes"
 	"github.com/lightstep/lightstep-tracer-go/constants"
-	"github.com/opentracing/opentracing-go"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/opentracing/opentracing-go"
 )
 
 var _ = Describe("TracerImpl", func() {
@@ -36,7 +36,7 @@ var _ = Describe("TracerImpl", func() {
 
 		opts = Options{
 			AccessToken: accessToken,
-			Tags: tags,
+			Tags:        tags,
 			ConnFactory: fakeConn,
 		}
 	})


### PR DESCRIPTION
The following changes have been implemented in this fix which were causing the tests to fail:
- restore sending a report even when it doesn't contain any spans
- if the byte size is not larger than the MaxCallSendMsgSizeBytes, the report should still be sent

I believe this preserves the changes needed to support splitting large reports rather than dropping them, it would be great to test this out with skipper.